### PR TITLE
Allow the setting of mode, group and owner on share directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,18 @@ Example data bag item for a single share named `export` in the `shares` item.
       "id": "shares",
       "shares": {
         "export": {
-          "comment": "Exported Share",
-          "path": "/srv/export",
-          "guest ok": "no",
-          "printable": "no",
-          "write list": ["jtimberman"],
-          "create mask": "0664",
-          "directory mask": "0775"
+          "owner": "root",
+          "group": "jtimberman",
+          "mode": "0775",
+          "options": {
+            "comment": "Exported Share",
+            "path": "/srv/export",
+            "guest ok": "no",
+            "printable": "no",
+            "write list": ["jtimberman"],
+            "create mask": "0664",
+            "directory mask": "0775"
+          }
         }
       }
     }

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -21,8 +21,11 @@ users = nil
 shares = data_bag_item("samba", "shares")
 
 shares["shares"].each do |k,v|
-  if v.has_key?("path")
-    directory v["path"] do
+  if v.has_key?("options") && v["options"].has_key?("path")
+    directory v["options"]["path"] do
+      owner v.fetch("owner", "root")
+      group v.fetch("group", "root")
+      mode v.fetch("mode", 0755)
       recursive true
     end
   end

--- a/templates/default/smb.conf.erb
+++ b/templates/default/smb.conf.erb
@@ -18,7 +18,7 @@
 #============================ Share Definitions ==============================
 <% @shares.each do |share,option| -%>
 [<%= share %>]
-  <% option.each do |o,v| -%>
+  <% option["options"].each do |o,v| -%>
   <%= o %> = <%= v.respond_to?(:join) ? v.join(',') : v %>
   <% end -%>
 


### PR DESCRIPTION
Samba requires that the share directory has proper unix permissions before users can modify it. This pull request adds the functionality to set the owner, group and mode within the shares data bag.